### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,7 +6,7 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-DynamixelShield KEYWORD1
+DynamixelShield	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
@@ -14,10 +14,10 @@ DynamixelShield KEYWORD1
 
 begin	KEYWORD2
    
-scan  KEYWORD2
-ping  KEYWORD2
+scan	KEYWORD2
+ping	KEYWORD2
 addMotor	KEYWORD2
-setProtocolVersion  KEYWORD2 
+setProtocolVersion	KEYWORD2 
 write	KEYWORD2
 read	KEYWORD2
 
@@ -56,10 +56,10 @@ getCurAngle	KEYWORD2
 syncWriteBegin	KEYWORD2
 syncWriteEnd	KEYWORD2
 
-available KEYWORD2
-peek  KEYWORD2
-read  KEYWORD2
-flush KEYWORD2
+available	KEYWORD2
+peek	KEYWORD2
+read	KEYWORD2
+flush	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE currently requires the use of a tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords

Some regressions to incorrect keyword separators occurred when you resolved the merge conflict for my previous pull request (https://github.com/ROBOTIS-GIT/DynamixelShield/pull/1).