### PR TITLE
Added comment to provide information on AX MX default use of protocol 1 communications.

### DIFF
--- a/examples/advanced/can2dynamixel/can2dynamixel.ino
+++ b/examples/advanced/can2dynamixel/can2dynamixel.ino
@@ -95,6 +95,8 @@ const uint8_t RX_BUFFER_SIZE = 30;
 const CanBitRate CAN_BUADRATE = CanBitRate::BR_1000kBPS_16MHZ;
 
 // Define the DYNAMIXEL Protocol version to use.
+// MX and AX servos use DYNAMIXEL Protocol 1.0 by default.
+// to use MX and AX servos with this example, change the following line to: const float DXL_PROTOCOL_VERSION = 1.0;
 const float DXL_PROTOCOL_VERSION = 2.0;
 // Define the Baud Rate of DYNAMIXEL to use. Recommend not to exceed 1Mbps.
 const uint32_t DXL_BUADRATE = 1000000;

--- a/examples/advanced/pid_tuning/pid_tuning.ino
+++ b/examples/advanced/pid_tuning/pid_tuning.ino
@@ -39,6 +39,8 @@
 
 const uint8_t DXL_ID = 1;
 const uint32_t DXL_BAUDRATE = 57600;
+// MX and AX servos use DYNAMIXEL Protocol 1.0 by default.
+// to use MX and AX servos with this example, change the following line to: const float DXL_PROTOCOL_VERSION = 1.0;
 const float DXL_PROTOCOL_VERSION = 2.0;
 
 int32_t goal_position[2] = {1200, 1600};

--- a/examples/advanced/rc_pwm2dynamixel/rc_pwm2dynamixel.ino
+++ b/examples/advanced/rc_pwm2dynamixel/rc_pwm2dynamixel.ino
@@ -40,7 +40,8 @@ DynamixelShield dxl;
 
 // Number of PWM Channels
 const uint8_t PWM_CHANNEL_SIZE = 8;
-// DYNAMIXEL Protocol Version [1.0 / 2.0]
+// MX and AX servos use DYNAMIXEL Protocol 1.0 by default.
+// to use MX and AX servos with this example, change the following line to: const float DXL_PROTOCOL_VERSION = 1.0;
 const float DXL_PROTOCOL_VERSION = 2.0;
 // DYNAMIXEL Baudrate
 const uint32_t DXL_BUADRATE = 1000000;

--- a/examples/advanced/read_write_ControlTableItem/read_write_ControlTableItem.ino
+++ b/examples/advanced/read_write_ControlTableItem/read_write_ControlTableItem.ino
@@ -135,6 +135,8 @@ using namespace ControlTableItem;
 void setup() {
   // put your setup code here, to run once:
   DEBUG_SERIAL.begin(115200);
+// MX and AX servos use DYNAMIXEL Protocol 1.0 by default.
+// to use MX and AX servos with this example, change the following line to: const float DXL_PROTOCOL_VERSION = 1.0;
   dxl.setPortProtocolVersion(2.0);
   dxl.begin(57600);
   dxl.scan();

--- a/examples/advanced/sync_read_write_position/sync_read_write_position.ino
+++ b/examples/advanced/sync_read_write_position/sync_read_write_position.ino
@@ -72,6 +72,8 @@
 */
 
 const uint8_t BROADCAST_ID = 254;
+// MX and AX servos use DYNAMIXEL Protocol 1.0 by default.
+// to use MX and AX servos with this example, change the following line to: const float DYNAMIXEL_PROTOCOL_VERSION = 1.0;
 const float DYNAMIXEL_PROTOCOL_VERSION = 2.0;
 const uint8_t DXL_ID_CNT = 2;
 const uint8_t DXL_ID_LIST[DXL_ID_CNT] = {1, 2};

--- a/examples/advanced/sync_read_write_velocity/sync_read_write_velocity.ino
+++ b/examples/advanced/sync_read_write_velocity/sync_read_write_velocity.ino
@@ -73,6 +73,8 @@
 */
 
 const uint8_t BROADCAST_ID = 254;
+// MX and AX servos use DYNAMIXEL Protocol 1.0 by default.
+// to use MX and AX servos with this example, change the following line to: const float DYNAMIXEL_PROTOCOL_VERSION = 1.0;
 const float DYNAMIXEL_PROTOCOL_VERSION = 2.0;
 const uint8_t DXL_ID_CNT = 2;
 const uint8_t DXL_ID_LIST[DXL_ID_CNT] = {1, 2};

--- a/examples/basic/baudrate/baudrate.ino
+++ b/examples/basic/baudrate/baudrate.ino
@@ -27,6 +27,8 @@
 #endif
 
 const uint8_t DXL_ID = 1;
+// MX and AX servos use DYNAMIXEL Protocol 1.0 by default.
+// to use MX and AX servos with this example, change the following line to: const float DXL_PROTOCOL_VERSION = 1.0;
 const float DXL_PROTOCOL_VERSION = 2.0;
 uint32_t BAUDRATE = 57600;
 uint32_t NEW_BAUDRATE = 1000000; //1Mbsp

--- a/examples/basic/current_mode/current_mode.ino
+++ b/examples/basic/current_mode/current_mode.ino
@@ -27,6 +27,8 @@
 #endif
 
 const uint8_t DXL_ID = 1;
+// MX and AX servos use DYNAMIXEL Protocol 1.0 by default.
+// to use MX and AX servos with this example, change the following line to: const float DXL_PROTOCOL_VERSION = 1.0;
 const float DXL_PROTOCOL_VERSION = 2.0;
 
 DynamixelShield dxl;

--- a/examples/basic/current_position_mode/current_position_mode.ino
+++ b/examples/basic/current_position_mode/current_position_mode.ino
@@ -31,6 +31,8 @@
 #endif
 
 const uint8_t DXL_ID = 1;
+// MX and AX servos use DYNAMIXEL Protocol 1.0 by default.
+// to use MX and AX servos with this example, change the following line to: const float DXL_PROTOCOL_VERSION = 1.0;
 const float DXL_PROTOCOL_VERSION = 2.0;
 
 DynamixelShield dxl;

--- a/examples/basic/id/id.ino
+++ b/examples/basic/id/id.ino
@@ -28,6 +28,8 @@
 
 
 const uint8_t DEFAULT_DXL_ID = 1;
+// MX and AX servos use DYNAMIXEL Protocol 1.0 by default.
+// to use MX and AX servos with this example, change the following line to: const float DXL_PROTOCOL_VERSION = 1.0;
 const float DXL_PROTOCOL_VERSION = 2.0;
 
 DynamixelShield dxl;

--- a/examples/basic/led/led.ino
+++ b/examples/basic/led/led.ino
@@ -17,6 +17,8 @@
 #include <DynamixelShield.h>
 
 const uint8_t DXL_ID = 1;
+// MX and AX servos use DYNAMIXEL Protocol 1.0 by default.
+// to use MX and AX servos with this example, change the following line to: const float DXL_PROTOCOL_VERSION = 1.0;
 const float DXL_PROTOCOL_VERSION = 2.0;
 
 DynamixelShield dxl;

--- a/examples/basic/operating_mode/operating_mode.ino
+++ b/examples/basic/operating_mode/operating_mode.ino
@@ -37,6 +37,8 @@
 #endif
 
 const uint8_t DXL_ID = 1;
+// MX and AX servos use DYNAMIXEL Protocol 1.0 by default.
+// to use MX and AX servos with this example, change the following line to: const float DXL_PROTOCOL_VERSION = 1.0;
 const float DXL_PROTOCOL_VERSION = 2.0;
 
 DynamixelShield dxl;

--- a/examples/basic/ping/ping.ino
+++ b/examples/basic/ping/ping.ino
@@ -27,6 +27,8 @@
 #endif
 
 const uint8_t DXL_ID = 1;
+// MX and AX servos use DYNAMIXEL Protocol 1.0 by default.
+// to use MX and AX servos with this example, change the following line to: const float DXL_PROTOCOL_VERSION = 1.0;
 const float DXL_PROTOCOL_VERSION = 2.0;
 
 DynamixelShield dxl;

--- a/examples/basic/position_mode/position_mode.ino
+++ b/examples/basic/position_mode/position_mode.ino
@@ -27,6 +27,8 @@
 #endif
 
 const uint8_t DXL_ID = 1;
+// MX and AX servos use DYNAMIXEL Protocol 1.0 by default.
+// to use MX and AX servos with this example, change the following line to: const float DXL_PROTOCOL_VERSION = 1.0;
 const float DXL_PROTOCOL_VERSION = 2.0;
 
 DynamixelShield dxl;

--- a/examples/basic/profile_velocity_acceleration/profile_velocity_acceleration.ino
+++ b/examples/basic/profile_velocity_acceleration/profile_velocity_acceleration.ino
@@ -32,6 +32,8 @@
 #endif
 
 const uint8_t DXL_ID = 1;
+// MX and AX servos use DYNAMIXEL Protocol 1.0 by default.
+// to use MX and AX servos with this example, change the following line to: const float DXL_PROTOCOL_VERSION = 1.0;
 const float DXL_PROTOCOL_VERSION = 2.0;
 
 DynamixelShield dxl;

--- a/examples/basic/pwm_mode/pwm_mode.ino
+++ b/examples/basic/pwm_mode/pwm_mode.ino
@@ -27,6 +27,8 @@
 #endif
 
 const uint8_t DXL_ID = 1;
+// MX and AX servos use DYNAMIXEL Protocol 1.0 by default.
+// to use MX and AX servos with this example, change the following line to: const float DXL_PROTOCOL_VERSION = 1.0;
 const float DXL_PROTOCOL_VERSION = 2.0;
 
 DynamixelShield dxl;

--- a/examples/basic/torque/torque.ino
+++ b/examples/basic/torque/torque.ino
@@ -21,6 +21,8 @@
 #include <DynamixelShield.h>
 
 const uint8_t DXL_ID = 1;
+// MX and AX servos use DYNAMIXEL Protocol 1.0 by default.
+// to use MX and AX servos with this example, change the following line to: const float DXL_PROTOCOL_VERSION = 1.0;
 const float DXL_PROTOCOL_VERSION = 2.0;
 
 DynamixelShield dxl;

--- a/examples/basic/velocity_mode/velocity_mode.ino
+++ b/examples/basic/velocity_mode/velocity_mode.ino
@@ -27,6 +27,8 @@
 #endif
 
 const uint8_t DXL_ID = 1;
+// MX and AX servos use DYNAMIXEL Protocol 1.0 by default.
+// to use MX and AX servos with this example, change the following line to: const float DXL_PROTOCOL_VERSION = 1.0;
 const float DXL_PROTOCOL_VERSION = 2.0;
 
 DynamixelShield dxl;

--- a/examples/dynamixel_protocol/factory_reset/factory_reset.ino
+++ b/examples/dynamixel_protocol/factory_reset/factory_reset.ino
@@ -28,6 +28,8 @@
 
 #define TIMEOUT 10    //default communication timeout 10ms
 const uint8_t DXL_ID = 1;
+// MX and AX servos use DYNAMIXEL Protocol 1.0 by default.
+// to use MX and AX servos with this example, change the following line to: const float DXL_PROTOCOL_VERSION = 1.0;
 const float DXL_PROTOCOL_VERSION = 2.0;
 
 bool ret = false;

--- a/examples/dynamixel_protocol/ping/ping.ino
+++ b/examples/dynamixel_protocol/ping/ping.ino
@@ -38,6 +38,8 @@ uint8_t ret = 0;
 uint8_t recv_count = 0;
 
 const uint8_t DXL_ID = BROADCAST_ID;
+// MX and AX servos use DYNAMIXEL Protocol 1.0 by default.
+// to use MX and AX servos with this example, change the following line to: const float DXL_PROTOCOL_VERSION = 1.0;
 const float DXL_PROTOCOL_VERSION = 2.0;
 
 DynamixelShield dxl;

--- a/examples/dynamixel_protocol/reboot/reboot.ino
+++ b/examples/dynamixel_protocol/reboot/reboot.ino
@@ -28,6 +28,8 @@
 
 #define TIMEOUT 10    //default communication timeout 10ms
 const uint8_t DXL_ID = 1;
+// MX and AX servos use DYNAMIXEL Protocol 1.0 by default.
+// to use MX and AX servos with this example, change the following line to: const float DXL_PROTOCOL_VERSION = 1.0;
 const float DXL_PROTOCOL_VERSION = 2.0;
 uint8_t option = 0;
 


### PR DESCRIPTION
Hopefully, this will make it easier for first time users that have AX/MX servos by providing clear instructions to change the active protocol version.

Companion to https://github.com/ROBOTIS-GIT/Dynamixel2Arduino/pull/124